### PR TITLE
[Epic] 업체 도메인 생성/조회/수정/삭제 API 구현

### DIFF
--- a/company/build.gradle
+++ b/company/build.gradle
@@ -32,11 +32,13 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/company/build.gradle
+++ b/company/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/company/build.gradle
+++ b/company/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/company/src/main/java/com/nangman/company/CompanyApplication.java
+++ b/company/src/main/java/com/nangman/company/CompanyApplication.java
@@ -2,7 +2,9 @@ package com.nangman.company;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class CompanyApplication {
 

--- a/company/src/main/java/com/nangman/company/CompanyApplication.java
+++ b/company/src/main/java/com/nangman/company/CompanyApplication.java
@@ -2,9 +2,11 @@ package com.nangman.company;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
+@EnableDiscoveryClient
 @SpringBootApplication
 public class CompanyApplication {
 

--- a/company/src/main/java/com/nangman/company/application/dto/HubDto.java
+++ b/company/src/main/java/com/nangman/company/application/dto/HubDto.java
@@ -1,0 +1,11 @@
+package com.nangman.company.application.dto;
+
+import java.util.UUID;
+
+public record HubDto(
+        UUID hubId,
+        String name,
+        String address,
+        UserDto manager
+) {
+}

--- a/company/src/main/java/com/nangman/company/application/dto/UserDto.java
+++ b/company/src/main/java/com/nangman/company/application/dto/UserDto.java
@@ -1,0 +1,22 @@
+package com.nangman.company.application.dto;
+
+import com.nangman.company.domain.enums.UserRole;
+import java.util.UUID;
+
+public record UserDto(
+        UUID userId,
+        String username,
+        String name,
+        UserRole role,
+        String slackId
+) {
+    public static UserDto createTmpUser() {
+        return new UserDto(
+                UUID.randomUUID(),
+                "username",
+                "name",
+                UserRole.AGENT,
+                "slackId"
+        );
+    }
+}

--- a/company/src/main/java/com/nangman/company/application/dto/request/CompanyPostRequest.java
+++ b/company/src/main/java/com/nangman/company/application/dto/request/CompanyPostRequest.java
@@ -1,0 +1,23 @@
+package com.nangman.company.application.dto.request;
+
+import com.nangman.company.domain.entity.Company;
+import com.nangman.company.domain.enums.CompanyType;
+import java.util.UUID;
+
+public record CompanyPostRequest(
+        UUID hubId,
+        UUID agentId,
+        String name,
+        CompanyType type,
+        String address
+) {
+    public Company toEntity() {
+        return Company.builder()
+                .hubId(hubId)
+                .agentId(agentId)
+                .name(name)
+                .type(type)
+                .address(address)
+                .build();
+    }
+}

--- a/company/src/main/java/com/nangman/company/application/dto/request/CompanyPutRequest.java
+++ b/company/src/main/java/com/nangman/company/application/dto/request/CompanyPutRequest.java
@@ -1,0 +1,13 @@
+package com.nangman.company.application.dto.request;
+
+import com.nangman.company.domain.enums.CompanyType;
+import java.util.UUID;
+
+public record CompanyPutRequest(
+        String name,
+        UUID hubId,
+        UUID agentId,
+        CompanyType type,
+        String address
+) {
+}

--- a/company/src/main/java/com/nangman/company/application/dto/response/CompanyGetResponse.java
+++ b/company/src/main/java/com/nangman/company/application/dto/response/CompanyGetResponse.java
@@ -1,0 +1,25 @@
+package com.nangman.company.application.dto.response;
+
+import com.nangman.company.application.dto.HubDto;
+import com.nangman.company.application.dto.UserDto;
+import com.nangman.company.domain.entity.Company;
+import com.nangman.company.domain.enums.CompanyType;
+import java.util.UUID;
+
+public record CompanyGetResponse(
+        UUID companyId,
+        String name,
+        HubDto hub,
+        CompanyType type,
+        UserDto agent
+) {
+    public static CompanyGetResponse of(Company company, HubDto hub, UserDto agent) {
+        return new CompanyGetResponse(
+                company.getId(),
+                company.getName(),
+                hub,
+                company.getType(),
+                agent
+        );
+    }
+}

--- a/company/src/main/java/com/nangman/company/application/dto/response/CompanyPostResponse.java
+++ b/company/src/main/java/com/nangman/company/application/dto/response/CompanyPostResponse.java
@@ -1,0 +1,12 @@
+package com.nangman.company.application.dto.response;
+
+import com.nangman.company.domain.entity.Company;
+import java.util.UUID;
+
+public record CompanyPostResponse(
+        UUID companyId
+) {
+    public static CompanyPostResponse from(Company company) {
+        return new CompanyPostResponse(company.getId());
+    }
+}

--- a/company/src/main/java/com/nangman/company/application/dto/response/CompanyPutResponse.java
+++ b/company/src/main/java/com/nangman/company/application/dto/response/CompanyPutResponse.java
@@ -1,0 +1,25 @@
+package com.nangman.company.application.dto.response;
+
+import com.nangman.company.application.dto.request.CompanyPutRequest;
+import com.nangman.company.domain.entity.Company;
+import com.nangman.company.domain.enums.CompanyType;
+import java.util.UUID;
+
+public record CompanyPutResponse(
+        UUID companyId,
+        String name,
+        UUID hubId,
+        UUID agentId,
+        CompanyType type,
+        String address
+) {
+    public static CompanyPutResponse from(Company company) {
+        return new CompanyPutResponse(
+                company.getId(),
+                company.getName(),
+                company.getHubId(),
+                company.getAgentId(),
+                company.getType(),
+                company.getAddress());
+    }
+}

--- a/company/src/main/java/com/nangman/company/application/service/CompanyService.java
+++ b/company/src/main/java/com/nangman/company/application/service/CompanyService.java
@@ -1,4 +1,19 @@
 package com.nangman.company.application.service;
 
+import com.nangman.company.application.dto.request.CompanyPostRequest;
+import com.nangman.company.application.dto.response.CompanyPostResponse;
+import com.nangman.company.domain.entity.Company;
+import com.nangman.company.presentation.CompanyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class CompanyService {
+    private final CompanyRepository companyRepository;
+
+    public CompanyPostResponse createCompany(CompanyPostRequest request) {
+        Company company = companyRepository.save(request.toEntity());
+        return CompanyPostResponse.from(company);
+    }
 }

--- a/company/src/main/java/com/nangman/company/application/service/CompanyService.java
+++ b/company/src/main/java/com/nangman/company/application/service/CompanyService.java
@@ -1,6 +1,9 @@
 package com.nangman.company.application.service;
 
+import com.nangman.company.application.dto.HubDto;
+import com.nangman.company.application.dto.UserDto;
 import com.nangman.company.application.dto.request.CompanyPostRequest;
+import com.nangman.company.application.dto.response.CompanyGetResponse;
 import com.nangman.company.application.dto.response.CompanyPostResponse;
 import com.nangman.company.domain.entity.Company;
 import com.nangman.company.domain.enums.UserRole;
@@ -31,6 +34,16 @@ public class CompanyService {
 
         Company company = companyRepository.save(request.toEntity());
         return CompanyPostResponse.from(company);
+    }
+
+    public CompanyGetResponse getCompany(UUID companyId) {
+        Company company = companyRepository.getById(companyId);
+        // TODO: Hub, Agent 가져오는 Feign Client 개발
+        // HubDto hub = hubClient.getHubById(company.getHubId());
+        // UserDto agent = userClient.getUserById(company.getAgentId());
+        return CompanyGetResponse.of(company,
+                new HubDto(UUID.randomUUID(), "name", "address", UserDto.createTmpUser()),
+                UserDto.createTmpUser());
     }
 
     private UUID getUserIdFromAuthentication() {

--- a/company/src/main/java/com/nangman/company/application/service/CompanyService.java
+++ b/company/src/main/java/com/nangman/company/application/service/CompanyService.java
@@ -77,6 +77,21 @@ public class CompanyService {
         return CompanyPutResponse.from(company);
     }
 
+    @Transactional
+    public void deleteCompany(UUID companyId) {
+        Company company = companyRepository.getById(companyId);
+        // TODO: MANAGER는 담당 HUB의 업체만 삭제 가능 -> HubClient
+        if (getUserRoleFromAuthentication() == UserRole.MANAGER) {
+            // UUID hubId = hubClient.getHubByManagerId(managerId);
+            UUID hubId = UUID.randomUUID();
+            if(!company.getHubId().equals(hubId)) {
+                throw new HubNotMatchedException();
+            }
+        }
+
+        company.updateIsDeleted(getUserIdFromAuthentication());
+    }
+
     private UUID getUserIdFromAuthentication() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || authentication.getAuthorities().isEmpty()) {

--- a/company/src/main/java/com/nangman/company/application/service/CompanyService.java
+++ b/company/src/main/java/com/nangman/company/application/service/CompanyService.java
@@ -5,6 +5,8 @@ import com.nangman.company.application.dto.UserDto;
 import com.nangman.company.application.dto.request.CompanyPostRequest;
 import com.nangman.company.application.dto.response.CompanyGetResponse;
 import com.nangman.company.application.dto.response.CompanyPostResponse;
+import com.nangman.company.common.exception.ExceptionStatus;
+import com.nangman.company.common.exception.HubNotMatchedException;
 import com.nangman.company.domain.entity.Company;
 import com.nangman.company.domain.enums.UserRole;
 import com.nangman.company.presentation.CompanyRepository;
@@ -27,8 +29,7 @@ public class CompanyService {
             // UUID hubId = hubClient.getHubId(managerId);
             UUID hubId = UUID.randomUUID();
             if (!request.hubId().equals(hubId)) {
-                // TODO: Exception 처리
-                log.info("해당 HUB ID는 담당 HUB가 아닙니다.");
+                throw new HubNotMatchedException();
             }
         }
 

--- a/company/src/main/java/com/nangman/company/application/service/CompanyService.java
+++ b/company/src/main/java/com/nangman/company/application/service/CompanyService.java
@@ -1,0 +1,4 @@
+package com.nangman.company.application.service;
+
+public class CompanyService {
+}

--- a/company/src/main/java/com/nangman/company/application/service/CompanyService.java
+++ b/company/src/main/java/com/nangman/company/application/service/CompanyService.java
@@ -26,7 +26,7 @@ public class CompanyService {
     public CompanyPostResponse createCompany(CompanyPostRequest request) {
         // TODO: UserRole이 MANAGER면 request hub ID와 담당자의 hub ID가 같은 지 확인
         if (getUserRoleFromAuthentication() == UserRole.MANAGER) {
-            // UUID hubId = hubClient.getHubId(managerId);
+            // UUID hubId = hubClient.getHubByManagerId(managerId);
             UUID hubId = UUID.randomUUID();
             if (!request.hubId().equals(hubId)) {
                 throw new HubNotMatchedException();

--- a/company/src/main/java/com/nangman/company/application/service/CompanyService.java
+++ b/company/src/main/java/com/nangman/company/application/service/CompanyService.java
@@ -70,6 +70,9 @@ public class CompanyService {
             }
         }
 
+        // TODO: HUB 수정 시 존재하는 HUB인지 검증 필요 -> HubClient
+        // TODO: AGENT 수정 시 request agentId가 AGENT role 가진 유저인지 검증 필요 -> UserClient
+
         company.updateAll(request);
         return CompanyPutResponse.from(company);
     }

--- a/company/src/main/java/com/nangman/company/application/service/CompanyService.java
+++ b/company/src/main/java/com/nangman/company/application/service/CompanyService.java
@@ -3,19 +3,23 @@ package com.nangman.company.application.service;
 import com.nangman.company.application.dto.HubDto;
 import com.nangman.company.application.dto.UserDto;
 import com.nangman.company.application.dto.request.CompanyPostRequest;
+import com.nangman.company.application.dto.request.CompanyPutRequest;
 import com.nangman.company.application.dto.response.CompanyGetResponse;
 import com.nangman.company.application.dto.response.CompanyPostResponse;
-import com.nangman.company.common.exception.ExceptionStatus;
+import com.nangman.company.application.dto.response.CompanyPutResponse;
+import com.nangman.company.common.exception.AgentMismatchException;
 import com.nangman.company.common.exception.HubNotMatchedException;
 import com.nangman.company.domain.entity.Company;
 import com.nangman.company.domain.enums.UserRole;
 import com.nangman.company.presentation.CompanyRepository;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -45,6 +49,29 @@ public class CompanyService {
         return CompanyGetResponse.of(company,
                 new HubDto(UUID.randomUUID(), "name", "address", UserDto.createTmpUser()),
                 UserDto.createTmpUser());
+    }
+
+    @Transactional
+    public CompanyPutResponse modifyCompany(UUID companyId, CompanyPutRequest request) {
+        Company company = companyRepository.getById(companyId);
+
+        if (getUserRoleFromAuthentication() == UserRole.AGENT) {
+            if (!Objects.equals(getUserIdFromAuthentication(), company.getAgentId())) {
+                throw new AgentMismatchException();
+            }
+        }
+
+        // TODO: UserRole이 MANAGER면 담당 허브의 업체만 수정 가능
+        else if (getUserRoleFromAuthentication() == UserRole.MANAGER) {
+            // UUID hubId = hubClient.getHubByManagerId(managerId);
+            UUID hubId = UUID.randomUUID();
+            if (!request.hubId().equals(hubId)) {
+                throw new HubNotMatchedException();
+            }
+        }
+
+        company.updateAll(request);
+        return CompanyPutResponse.from(company);
     }
 
     private UUID getUserIdFromAuthentication() {

--- a/company/src/main/java/com/nangman/company/application/service/CompanyService.java
+++ b/company/src/main/java/com/nangman/company/application/service/CompanyService.java
@@ -3,17 +3,49 @@ package com.nangman.company.application.service;
 import com.nangman.company.application.dto.request.CompanyPostRequest;
 import com.nangman.company.application.dto.response.CompanyPostResponse;
 import com.nangman.company.domain.entity.Company;
+import com.nangman.company.domain.enums.UserRole;
 import com.nangman.company.presentation.CompanyRepository;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CompanyService {
     private final CompanyRepository companyRepository;
 
     public CompanyPostResponse createCompany(CompanyPostRequest request) {
+        // TODO: UserRole이 MANAGER면 request hub ID와 담당자의 hub ID가 같은 지 확인
+        if (getUserRoleFromAuthentication() == UserRole.MANAGER) {
+            // UUID hubId = hubClient.getHubId(managerId);
+            UUID hubId = UUID.randomUUID();
+            if (!request.hubId().equals(hubId)) {
+                // TODO: Exception 처리
+                log.info("해당 HUB ID는 담당 HUB가 아닙니다.");
+            }
+        }
+
         Company company = companyRepository.save(request.toEntity());
         return CompanyPostResponse.from(company);
+    }
+
+    private UUID getUserIdFromAuthentication() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication.getAuthorities().isEmpty()) {
+            return null;
+        }
+        return UUID.fromString(authentication.getPrincipal().toString());
+    }
+
+    private UserRole getUserRoleFromAuthentication() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication.getAuthorities().isEmpty()) {
+            return null;
+        }
+        return UserRole.valueOf(authentication.getAuthorities().iterator().next().getAuthority());
     }
 }

--- a/company/src/main/java/com/nangman/company/common/config/UserAuditorAware.java
+++ b/company/src/main/java/com/nangman/company/common/config/UserAuditorAware.java
@@ -1,4 +1,4 @@
-package com.nangman.company.config;
+package com.nangman.company.common.config;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;

--- a/company/src/main/java/com/nangman/company/common/config/WebConfig.java
+++ b/company/src/main/java/com/nangman/company/common/config/WebConfig.java
@@ -1,0 +1,44 @@
+package com.nangman.company.common.config;
+
+import com.nangman.company.common.interceptor.AuthInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthInterceptor authInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor)
+                .addPathPatterns("/**");
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf((csrf) -> csrf.disable())
+                .authorizeHttpRequests((authorizeHttpRequests) ->
+                        authorizeHttpRequests
+                                .requestMatchers(PathRequest.toStaticResources().atCommonLocations())
+                                .permitAll()
+                                .requestMatchers("/**").permitAll()
+                                .anyRequest().authenticated()
+                )
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                );
+
+        return http.build();
+    }
+}

--- a/company/src/main/java/com/nangman/company/common/exception/AgentMismatchException.java
+++ b/company/src/main/java/com/nangman/company/common/exception/AgentMismatchException.java
@@ -1,0 +1,7 @@
+package com.nangman.company.common.exception;
+
+public class AgentMismatchException extends DefaultException {
+    public AgentMismatchException() {
+        super(ExceptionStatus.AGENT_MISMATCHED);
+    }
+}

--- a/company/src/main/java/com/nangman/company/common/exception/CompanyNotFoundException.java
+++ b/company/src/main/java/com/nangman/company/common/exception/CompanyNotFoundException.java
@@ -1,0 +1,9 @@
+package com.nangman.company.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class CompanyNotFoundException extends DefaultException {
+    public CompanyNotFoundException() {
+        super(ExceptionStatus.COMPANY_NOT_FOUND);
+    }
+}

--- a/company/src/main/java/com/nangman/company/common/exception/CompanyNotFoundException.java
+++ b/company/src/main/java/com/nangman/company/common/exception/CompanyNotFoundException.java
@@ -1,7 +1,5 @@
 package com.nangman.company.common.exception;
 
-import org.springframework.http.HttpStatus;
-
 public class CompanyNotFoundException extends DefaultException {
     public CompanyNotFoundException() {
         super(ExceptionStatus.COMPANY_NOT_FOUND);

--- a/company/src/main/java/com/nangman/company/common/exception/DefaultException.java
+++ b/company/src/main/java/com/nangman/company/common/exception/DefaultException.java
@@ -1,0 +1,15 @@
+package com.nangman.company.common.exception;
+
+public class DefaultException extends RuntimeException {
+    private final ExceptionStatus exceptionStatus;
+    public DefaultException(ExceptionStatus exceptionStatus) {
+        this.exceptionStatus = exceptionStatus;
+    }
+    @Override
+    public String getMessage() {
+        return exceptionStatus.getMessage();
+    }
+    public int getStatus() {
+        return exceptionStatus.getStatus();
+    }
+}

--- a/company/src/main/java/com/nangman/company/common/exception/ExceptionStatus.java
+++ b/company/src/main/java/com/nangman/company/common/exception/ExceptionStatus.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ExceptionStatus {
-//    COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "CUSTOM_001", "Company를 찾을 수 없습니다.");
+    COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "CUSTOM_001", "Company를 찾을 수 없습니다.");
 
     private final int status;
     private final String customCode;

--- a/company/src/main/java/com/nangman/company/common/exception/ExceptionStatus.java
+++ b/company/src/main/java/com/nangman/company/common/exception/ExceptionStatus.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ExceptionStatus {
-    COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "CUSTOM_001", "Company를 찾을 수 없습니다.");
+    COMPANY_NOT_FOUND(HttpStatus.BAD_REQUEST, "COMPANY_001", "Company를 찾을 수 없습니다."),
+    HUB_NOT_MATCHED(HttpStatus.BAD_REQUEST, "COMPANY_002", "담당 Hub가 아닙니다.");
 
     private final int status;
     private final String customCode;

--- a/company/src/main/java/com/nangman/company/common/exception/ExceptionStatus.java
+++ b/company/src/main/java/com/nangman/company/common/exception/ExceptionStatus.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ExceptionStatus {
     COMPANY_NOT_FOUND(HttpStatus.BAD_REQUEST, "COMPANY_001", "Company를 찾을 수 없습니다."),
-    HUB_NOT_MATCHED(HttpStatus.BAD_REQUEST, "COMPANY_002", "담당 Hub가 아닙니다.");
+    HUB_NOT_MATCHED(HttpStatus.BAD_REQUEST, "COMPANY_002", "담당 Hub가 아닙니다."),
+    AGENT_MISMATCHED(HttpStatus.FORBIDDEN, "COMPANY_003", "해당 Hub의 담당자가 아닙니다.");
 
     private final int status;
     private final String customCode;

--- a/company/src/main/java/com/nangman/company/common/exception/ExceptionStatus.java
+++ b/company/src/main/java/com/nangman/company/common/exception/ExceptionStatus.java
@@ -1,0 +1,21 @@
+package com.nangman.company.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ExceptionStatus {
+//    COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "CUSTOM_001", "Company를 찾을 수 없습니다.");
+
+    private final int status;
+    private final String customCode;
+    private final String message;
+    private final String err;
+
+    ExceptionStatus(HttpStatus httpStatus, String customCode, String message) {
+        this.status = httpStatus.value();
+        this.customCode = customCode;
+        this.message = message;
+        this.err = httpStatus.getReasonPhrase();
+    }
+}

--- a/company/src/main/java/com/nangman/company/common/exception/GlobalExceptionHandler.java
+++ b/company/src/main/java/com/nangman/company/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.nangman.company.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(DefaultException.class)
+    public ResponseEntity<?> handleDefaultException(DefaultException e) {
+        log.error("handleDefaultException: {}", e.getMessage());
+        return ResponseEntity.status(e.getStatus()).body(e.getMessage());
+    }
+}

--- a/company/src/main/java/com/nangman/company/common/exception/HubNotMatchedException.java
+++ b/company/src/main/java/com/nangman/company/common/exception/HubNotMatchedException.java
@@ -1,0 +1,7 @@
+package com.nangman.company.common.exception;
+
+public class HubNotMatchedException extends DefaultException {
+    public HubNotMatchedException() {
+        super(ExceptionStatus.HUB_NOT_MATCHED);
+    }
+}

--- a/company/src/main/java/com/nangman/company/common/feign/HubClient.java
+++ b/company/src/main/java/com/nangman/company/common/feign/HubClient.java
@@ -15,4 +15,6 @@ public interface HubClient {
     @GetMapping("/hubs/managers/{managerId}")
     HubDto getHubByManagerId(@PathVariable UUID managerId);
 
+    // TODO: test 진행 시 fallback method 추가
+
 }

--- a/company/src/main/java/com/nangman/company/common/feign/HubClient.java
+++ b/company/src/main/java/com/nangman/company/common/feign/HubClient.java
@@ -1,0 +1,18 @@
+package com.nangman.company.common.feign;
+
+import com.nangman.company.application.dto.HubDto;
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "hub")
+public interface HubClient {
+
+    @GetMapping("/hubs/{id}")
+    HubDto getHubById(@PathVariable UUID id);
+
+    @GetMapping("/hubs/managers/{managerId}")
+    HubDto getHubByManagerId(@PathVariable UUID managerId);
+
+}

--- a/company/src/main/java/com/nangman/company/common/feign/UserClient.java
+++ b/company/src/main/java/com/nangman/company/common/feign/UserClient.java
@@ -1,0 +1,14 @@
+package com.nangman.company.common.feign;
+
+import com.nangman.company.application.dto.UserDto;
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "user")
+public interface UserClient {
+
+    @GetMapping("/users/{id}")
+    UserDto getUserById(@PathVariable UUID id);
+}

--- a/company/src/main/java/com/nangman/company/common/interceptor/Auth.java
+++ b/company/src/main/java/com/nangman/company/common/interceptor/Auth.java
@@ -1,0 +1,13 @@
+package com.nangman.company.common.interceptor;
+
+import com.nangman.company.domain.enums.UserRole;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Auth {
+    UserRole[] role() default {};
+}

--- a/company/src/main/java/com/nangman/company/common/interceptor/AuthInterceptor.java
+++ b/company/src/main/java/com/nangman/company/common/interceptor/AuthInterceptor.java
@@ -1,0 +1,60 @@
+package com.nangman.company.common.interceptor;
+
+import com.nangman.company.domain.enums.UserRole;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Collections;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class AuthInterceptor implements HandlerInterceptor {
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if (!(handler instanceof HandlerMethod)) {
+            return true;
+        }
+
+        HandlerMethod method = (HandlerMethod) handler;
+        Auth auth = method.getMethodAnnotation(Auth.class);
+        if (auth == null) {
+            return true;
+        }
+
+        String userRoleHeader = request.getHeader("X-User-Role");
+        String userIdHeader = request.getHeader("X-User-Id");
+
+        if (userRoleHeader == null || userIdHeader == null) {
+            // TODO: Exception 처리
+            log.info("User role or ID is required");
+        }
+
+        UUID userId = UUID.fromString(userIdHeader);
+        UserRole userRole = UserRole.valueOf(userRoleHeader);
+
+
+        for (UserRole allowedRole : auth.role()) {
+            if (allowedRole == userRole) {
+                SimpleGrantedAuthority authority = new SimpleGrantedAuthority(userRoleHeader);
+
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(userId, null, Collections.singleton(authority));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+                return true;
+            }
+        }
+
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        return false;
+    }
+}

--- a/company/src/main/java/com/nangman/company/config/UserAuditorAware.java
+++ b/company/src/main/java/com/nangman/company/config/UserAuditorAware.java
@@ -1,0 +1,32 @@
+package com.nangman.company.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.data.domain.AuditorAware;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserAuditorAware implements AuditorAware<UUID> {
+
+    private final HttpServletRequest request;
+
+    @Override
+    public Optional<UUID> getCurrentAuditor() {
+        // TODO: 추후 인가 로직 변경에 따른 수정 필요
+        String userIdHeader = request.getHeader("X-User-Id");
+        if (userIdHeader != null) {
+            try {
+                UUID userId = UUID.fromString(userIdHeader);
+                return Optional.of(userId);
+            } catch (IllegalArgumentException e) {
+                log.info("Invalid UUID in X-User-Id header: " + userIdHeader);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/company/src/main/java/com/nangman/company/domain/entity/BaseTimeEntity.java
+++ b/company/src/main/java/com/nangman/company/domain/entity/BaseTimeEntity.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.hibernate.annotations.ColumnDefault;
+import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -22,6 +23,7 @@ public class BaseTimeEntity {
     @Column(updatable = false, nullable = false)
     private LocalDateTime createdAt;
 
+    @CreatedBy
     private UUID createdBy;
 
     @LastModifiedDate

--- a/company/src/main/java/com/nangman/company/domain/entity/BaseTimeEntity.java
+++ b/company/src/main/java/com/nangman/company/domain/entity/BaseTimeEntity.java
@@ -1,0 +1,40 @@
+package com.nangman.company.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.hibernate.annotations.ColumnDefault;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EqualsAndHashCode
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    private UUID createdBy;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+
+    private UUID modifiedBy;
+
+    private LocalDateTime deletedAt;
+
+    private UUID deletedBy;
+
+    @Column(nullable = false)
+    @ColumnDefault("false")
+    private Boolean isDelete = false;
+
+}

--- a/company/src/main/java/com/nangman/company/domain/entity/BaseTimeEntity.java
+++ b/company/src/main/java/com/nangman/company/domain/entity/BaseTimeEntity.java
@@ -39,4 +39,11 @@ public class BaseTimeEntity {
     @ColumnDefault("false")
     private Boolean isDelete = false;
 
+    public void updateIsDeleted(UUID userId) {
+        this.isDelete = true;
+        this.modifiedBy = userId;
+        this.deletedAt = LocalDateTime.now();
+        this.deletedBy = userId;
+    }
+
 }

--- a/company/src/main/java/com/nangman/company/domain/entity/Company.java
+++ b/company/src/main/java/com/nangman/company/domain/entity/Company.java
@@ -1,5 +1,6 @@
 package com.nangman.company.domain.entity;
 
+import com.nangman.company.application.dto.request.CompanyPutRequest;
 import com.nangman.company.domain.enums.CompanyType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -46,4 +47,12 @@ public class Company extends BaseTimeEntity {
     @Column(length = 50, nullable = false)
     @Size(min = 1, max = 50)
     private String address;
+
+    public void updateAll(CompanyPutRequest request) {
+        this.hubId = request.hubId();
+        this.agentId = request.agentId();
+        this.name = request.name();
+        this.type = request.type();
+        this.address = request.address();
+    }
 }

--- a/company/src/main/java/com/nangman/company/domain/entity/Company.java
+++ b/company/src/main/java/com/nangman/company/domain/entity/Company.java
@@ -1,4 +1,45 @@
 package com.nangman.company.domain.entity;
 
+import com.nangman.company.domain.enums.CompanyType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "p_companies")
 public class Company {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private UUID hubId;
+
+    @Column(nullable = false)
+    private UUID agentId;
+
+    @Column(length = 20, nullable = false)
+    @Size(min = 1, max = 20)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 8, nullable = false)
+    private CompanyType type;
+
+    @Column(length = 50, nullable = false)
+    @Size(min = 1, max = 50)
+    private String address;
 }

--- a/company/src/main/java/com/nangman/company/domain/entity/Company.java
+++ b/company/src/main/java/com/nangman/company/domain/entity/Company.java
@@ -1,0 +1,4 @@
+package com.nangman.company.domain.entity;
+
+public class Company {
+}

--- a/company/src/main/java/com/nangman/company/domain/entity/Company.java
+++ b/company/src/main/java/com/nangman/company/domain/entity/Company.java
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "p_companies")
-public class Company {
+public class Company extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)

--- a/company/src/main/java/com/nangman/company/domain/entity/Company.java
+++ b/company/src/main/java/com/nangman/company/domain/entity/Company.java
@@ -12,12 +12,16 @@ import jakarta.persistence.Table;
 import jakarta.validation.constraints.Size;
 import java.util.UUID;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Table(name = "p_companies")
 public class Company extends BaseTimeEntity {
 

--- a/company/src/main/java/com/nangman/company/domain/enums/CompanyType.java
+++ b/company/src/main/java/com/nangman/company/domain/enums/CompanyType.java
@@ -1,0 +1,5 @@
+package com.nangman.company.domain.enums;
+
+public enum CompanyType {
+    SUPPLIER, RECEIVER, BOTH
+}

--- a/company/src/main/java/com/nangman/company/domain/enums/UserRole.java
+++ b/company/src/main/java/com/nangman/company/domain/enums/UserRole.java
@@ -1,0 +1,5 @@
+package com.nangman.company.domain.enums;
+
+public enum UserRole {
+    MASTER, MANAGER, SHIPPER, AGENT
+}

--- a/company/src/main/java/com/nangman/company/presentation/CompanyController.java
+++ b/company/src/main/java/com/nangman/company/presentation/CompanyController.java
@@ -1,4 +1,26 @@
 package com.nangman.company.presentation;
 
+import com.nangman.company.application.dto.request.CompanyPostRequest;
+import com.nangman.company.application.dto.response.CompanyPostResponse;
+import com.nangman.company.application.service.CompanyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/companies")
 public class CompanyController {
+    private final CompanyService companyService;
+
+    @PostMapping
+    public ResponseEntity<CompanyPostResponse> createCompany(
+            @RequestBody CompanyPostRequest request) {
+        // TODO: 접근 권한 제어 로직 추가
+        return ResponseEntity.ok(companyService.createCompany(request));
+    }
+
 }

--- a/company/src/main/java/com/nangman/company/presentation/CompanyController.java
+++ b/company/src/main/java/com/nangman/company/presentation/CompanyController.java
@@ -3,6 +3,8 @@ package com.nangman.company.presentation;
 import com.nangman.company.application.dto.request.CompanyPostRequest;
 import com.nangman.company.application.dto.response.CompanyPostResponse;
 import com.nangman.company.application.service.CompanyService;
+import com.nangman.company.common.interceptor.Auth;
+import com.nangman.company.domain.enums.UserRole;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,10 +18,10 @@ import org.springframework.web.bind.annotation.RestController;
 public class CompanyController {
     private final CompanyService companyService;
 
+    @Auth(role = {UserRole.MASTER, UserRole.MANAGER})
     @PostMapping
     public ResponseEntity<CompanyPostResponse> createCompany(
             @RequestBody CompanyPostRequest request) {
-        // TODO: 접근 권한 제어 로직 추가
         return ResponseEntity.ok(companyService.createCompany(request));
     }
 

--- a/company/src/main/java/com/nangman/company/presentation/CompanyController.java
+++ b/company/src/main/java/com/nangman/company/presentation/CompanyController.java
@@ -1,0 +1,4 @@
+package com.nangman.company.presentation;
+
+public class CompanyController {
+}

--- a/company/src/main/java/com/nangman/company/presentation/CompanyController.java
+++ b/company/src/main/java/com/nangman/company/presentation/CompanyController.java
@@ -29,7 +29,6 @@ public class CompanyController {
         return ResponseEntity.ok(companyService.createCompany(request));
     }
 
-    @Auth(role = {UserRole.MASTER, UserRole.MANAGER, UserRole.AGENT})
     @GetMapping("/{companyId}")
     public ResponseEntity<CompanyGetResponse> getCompany(@PathVariable UUID companyId) {
         return ResponseEntity.ok(companyService.getCompany(companyId));

--- a/company/src/main/java/com/nangman/company/presentation/CompanyController.java
+++ b/company/src/main/java/com/nangman/company/presentation/CompanyController.java
@@ -1,17 +1,21 @@
 package com.nangman.company.presentation;
 
 import com.nangman.company.application.dto.request.CompanyPostRequest;
+import com.nangman.company.application.dto.request.CompanyPutRequest;
 import com.nangman.company.application.dto.response.CompanyGetResponse;
 import com.nangman.company.application.dto.response.CompanyPostResponse;
+import com.nangman.company.application.dto.response.CompanyPutResponse;
 import com.nangman.company.application.service.CompanyService;
 import com.nangman.company.common.interceptor.Auth;
 import com.nangman.company.domain.enums.UserRole;
+import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,6 +36,13 @@ public class CompanyController {
     @GetMapping("/{companyId}")
     public ResponseEntity<CompanyGetResponse> getCompany(@PathVariable UUID companyId) {
         return ResponseEntity.ok(companyService.getCompany(companyId));
+    }
+
+    @Auth(role = {UserRole.MASTER, UserRole.MANAGER, UserRole.AGENT})
+    @PutMapping("/{companyId}")
+    public ResponseEntity<CompanyPutResponse> modifyCompany(@PathVariable UUID companyId,
+                                                            @RequestBody CompanyPutRequest request) {
+        return ResponseEntity.ok(companyService.modifyCompany(companyId, request));
     }
 
 }

--- a/company/src/main/java/com/nangman/company/presentation/CompanyController.java
+++ b/company/src/main/java/com/nangman/company/presentation/CompanyController.java
@@ -1,12 +1,16 @@
 package com.nangman.company.presentation;
 
 import com.nangman.company.application.dto.request.CompanyPostRequest;
+import com.nangman.company.application.dto.response.CompanyGetResponse;
 import com.nangman.company.application.dto.response.CompanyPostResponse;
 import com.nangman.company.application.service.CompanyService;
 import com.nangman.company.common.interceptor.Auth;
 import com.nangman.company.domain.enums.UserRole;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,6 +27,11 @@ public class CompanyController {
     public ResponseEntity<CompanyPostResponse> createCompany(
             @RequestBody CompanyPostRequest request) {
         return ResponseEntity.ok(companyService.createCompany(request));
+    }
+
+    @GetMapping("/{companyId}")
+    public ResponseEntity<CompanyGetResponse> getCompany(@PathVariable UUID companyId) {
+        return ResponseEntity.ok(companyService.getCompany(companyId));
     }
 
 }

--- a/company/src/main/java/com/nangman/company/presentation/CompanyController.java
+++ b/company/src/main/java/com/nangman/company/presentation/CompanyController.java
@@ -12,6 +12,7 @@ import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -43,6 +44,13 @@ public class CompanyController {
     public ResponseEntity<CompanyPutResponse> modifyCompany(@PathVariable UUID companyId,
                                                             @RequestBody CompanyPutRequest request) {
         return ResponseEntity.ok(companyService.modifyCompany(companyId, request));
+    }
+
+    @Auth(role = {UserRole.MASTER, UserRole.MANAGER})
+    @DeleteMapping("/{companyId}")
+    public ResponseEntity<Void> deleteCompany(@PathVariable UUID companyId) {
+        companyService.deleteCompany(companyId);
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/company/src/main/java/com/nangman/company/presentation/CompanyController.java
+++ b/company/src/main/java/com/nangman/company/presentation/CompanyController.java
@@ -29,6 +29,7 @@ public class CompanyController {
         return ResponseEntity.ok(companyService.createCompany(request));
     }
 
+    @Auth(role = {UserRole.MASTER, UserRole.MANAGER, UserRole.AGENT})
     @GetMapping("/{companyId}")
     public ResponseEntity<CompanyGetResponse> getCompany(@PathVariable UUID companyId) {
         return ResponseEntity.ok(companyService.getCompany(companyId));

--- a/company/src/main/java/com/nangman/company/presentation/CompanyRepository.java
+++ b/company/src/main/java/com/nangman/company/presentation/CompanyRepository.java
@@ -1,8 +1,13 @@
 package com.nangman.company.presentation;
 
+import com.nangman.company.common.exception.CompanyNotFoundException;
 import com.nangman.company.domain.entity.Company;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CompanyRepository extends JpaRepository<Company, UUID> {
+
+    default Company getById(UUID companyId) {
+        return findById(companyId).orElseThrow(CompanyNotFoundException::new);
+    }
 }

--- a/company/src/main/java/com/nangman/company/presentation/CompanyRepository.java
+++ b/company/src/main/java/com/nangman/company/presentation/CompanyRepository.java
@@ -1,4 +1,8 @@
 package com.nangman.company.presentation;
 
-public interface CompanyRepository {
+import com.nangman.company.domain.entity.Company;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CompanyRepository extends JpaRepository<Company, UUID> {
 }

--- a/company/src/main/java/com/nangman/company/presentation/CompanyRepository.java
+++ b/company/src/main/java/com/nangman/company/presentation/CompanyRepository.java
@@ -1,0 +1,4 @@
+package com.nangman.company.presentation;
+
+public interface CompanyRepository {
+}

--- a/company/src/main/resources/application.properties
+++ b/company/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=company

--- a/company/src/main/resources/application.yml
+++ b/company/src/main/resources/application.yml
@@ -1,0 +1,20 @@
+server:
+  port: 19093
+
+spring:
+  application:
+    name: company
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://localhost:5432/company
+    username:
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:19090/eureka


### PR DESCRIPTION
## 🔖 연관된 이슈
#1, #2, #11, #12, #25, #27

## 📂 작업 내용
- 업체(Company) 도메인 생성/조회/수정/삭제 API 구현했습니다.
- Interceptor로 접근 권한 제어 기능을 구현했습니다.
- FeignClient로 내부 서비스와 HTTP 통신하도록 구현했습니다.

## 📢 리뷰 참고사항
- 현재 FeignClient는 연동 테스트 전입니다.
